### PR TITLE
Fixing issue #121 Typos on homepage

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -46,8 +46,8 @@ class Home extends Component {
 					</p>
 					<h3>Want to do an extended talk?</h3>
 					<p>
-						We do accept extended talks but prefer presentors to have done a
-						lightning talk before. If you're unsure&nbsp;
+					We do accept extended talks, but prefer presentors to have done a lightning talk before. 
+					If you're unsure, please email us to discuss your talk.&nbsp;
 						<a
 							href="mailto:sandiegojs-organizers@googlegroups.com?subject=Extended%20talk%20request"
 							className='inline-link'>


### PR DESCRIPTION
changing 

Current: "We do accept extended talks but prefer presentors to have done a lightning talk before. If you're unsure please email us to discuss your talk."

to 

Suggestion: "We do accept extended talks, but prefer presentors to have done a lightning talk before. If you're unsure, please email us to discuss your talk.